### PR TITLE
Use free GH public runners instead of self-hosted ones

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In order to fix the Github Actions (currently they're timing out), one option is to use the GitHub-hosted runners, which are free for public repos. So here is the PR to fix this.

The related issue can be found here: https://github.com/dntsk/extdns/issues/4